### PR TITLE
Fix eliminados sysout y añadidas validaciones de spam para author e info

### DIFF
--- a/src/main/java/acme/features/administrator/task/AdministratorTaskCreateService.java
+++ b/src/main/java/acme/features/administrator/task/AdministratorTaskCreateService.java
@@ -118,7 +118,6 @@ public class AdministratorTaskCreateService implements AbstractCreateService<Adm
 		final Spam spamObject = this.spamRepository.findSpam();
 		
 		final List<String> spamWords = Arrays.asList(spamObject.getWords().split(", "));
-		System.out.println(spamWords);
 		
 		final String[] taskWords = text.toLowerCase().split(" ");
 		
@@ -128,14 +127,12 @@ public class AdministratorTaskCreateService implements AbstractCreateService<Adm
 		
 		for(final String word:taskWords) {
 			final String cleanWord = word.replaceAll("(?![À-ÿ\\u00f1\\u00d1a-zA-Z0-9]).", "");
-			System.out.println(cleanWord);
 			if(spamWords.contains(cleanWord)) {
 				numberSpamWords++;
 			}
 		}
 		
 		spamPercentaje = ((numberSpamWords/length)*100);
-		System.out.println(spamPercentaje);
 		if(spamPercentaje>spamObject.getThreshold()) {
 			return true;
 		}else {

--- a/src/main/java/acme/features/administrator/task/AdministratorTaskUpdateService.java
+++ b/src/main/java/acme/features/administrator/task/AdministratorTaskUpdateService.java
@@ -104,7 +104,6 @@ public class AdministratorTaskUpdateService implements AbstractUpdateService<Adm
 		final Spam spamObject = this.spamRepository.findSpam();
 		
 		final List<String> spamWords = Arrays.asList(spamObject.getWords().split(", "));
-		System.out.println(spamWords);
 		
 		final String[] taskWords = text.toLowerCase().split(" ");
 		
@@ -114,14 +113,12 @@ public class AdministratorTaskUpdateService implements AbstractUpdateService<Adm
 		
 		for(final String word:taskWords) {
 			final String cleanWord = word.replaceAll("(?![À-ÿ\\u00f1\\u00d1a-zA-Z0-9]).", "");
-			System.out.println(cleanWord);
 			if(spamWords.contains(cleanWord)) {
 				numberSpamWords++;
 			}
 		}
 		
 		spamPercentaje = ((numberSpamWords/length)*100);
-		System.out.println(spamPercentaje);
 		if(spamPercentaje>spamObject.getThreshold()) {
 			return true;
 		}else {

--- a/src/main/java/acme/features/anonymous/shout/AnonymousShoutCreateService.java
+++ b/src/main/java/acme/features/anonymous/shout/AnonymousShoutCreateService.java
@@ -91,9 +91,13 @@ public class AnonymousShoutCreateService implements AbstractCreateService<Anonym
 		assert entity != null;
 		assert errors != null;
 		
-		final boolean notSpam = this.esSpam(entity.getText());
+		final boolean notSpamText = this.esSpam(entity.getText());
+		final boolean notSpamAuthor = this.esSpam(entity.getAuthor());
+		final boolean notSpamInfo = this.esSpam(entity.getInfo());
 
-		errors.state(request, !notSpam, "text", "anonymous.shout.error.text");
+		errors.state(request, !notSpamText, "text", "anonymous.shout.error.text");
+		errors.state(request, !notSpamAuthor, "author", "anonymous.shout.error.text");
+		errors.state(request, !notSpamInfo, "info", "anonymous.shout.error.text");
 
 
 	}
@@ -116,7 +120,6 @@ public class AnonymousShoutCreateService implements AbstractCreateService<Anonym
 		final Spam spamObject = this.spamRepository.findSpam();
 		
 		final List<String> spamWords = Arrays.asList(spamObject.getWords().split(", "));
-		System.out.println(spamWords);
 		
 		final String[] shoutWords = text.toLowerCase().split(" ");
 		
@@ -126,14 +129,12 @@ public class AnonymousShoutCreateService implements AbstractCreateService<Anonym
 		
 		for(final String word:shoutWords) {
 			final String cleanWord = word.replaceAll("(?![À-ÿ\\u00f1\\u00d1a-zA-Z0-9]).", "");
-			System.out.println(cleanWord);
 			if(spamWords.contains(cleanWord)) {
 				numberSpamWords++;
 			}
 		}
 		
 		spamPercentaje = ((numberSpamWords/length)*100);
-		System.out.println(spamPercentaje);
 		if(spamPercentaje>spamObject.getThreshold()) {
 			return true;
 		}else {

--- a/src/main/java/acme/features/manager/task/ManagerTaskCreateService.java
+++ b/src/main/java/acme/features/manager/task/ManagerTaskCreateService.java
@@ -118,7 +118,6 @@ public class ManagerTaskCreateService implements AbstractCreateService<Manager, 
 		final Spam spamObject = this.spamRepository.findSpam();
 		
 		final List<String> spamWords = Arrays.asList(spamObject.getWords().split(", "));
-		System.out.println(spamWords);
 		
 		final String[] taskWords = text.toLowerCase().split(" ");
 		
@@ -128,14 +127,12 @@ public class ManagerTaskCreateService implements AbstractCreateService<Manager, 
 		
 		for(final String word:taskWords) {
 			final String cleanWord = word.replaceAll("(?![À-ÿ\\u00f1\\u00d1a-zA-Z0-9]).", "");
-			System.out.println(cleanWord);
 			if(spamWords.contains(cleanWord)) {
 				numberSpamWords++;
 			}
 		}
 		
 		spamPercentaje = ((numberSpamWords/length)*100);
-		System.out.println(spamPercentaje);
 		if(spamPercentaje>spamObject.getThreshold()) {
 			return true;
 		}else {

--- a/src/main/java/acme/features/manager/task/ManagerTaskUpdateService.java
+++ b/src/main/java/acme/features/manager/task/ManagerTaskUpdateService.java
@@ -106,7 +106,6 @@ public class ManagerTaskUpdateService implements AbstractUpdateService<Manager, 
 		final Spam spamObject = this.spamRepository.findSpam();
 		
 		final List<String> spamWords = Arrays.asList(spamObject.getWords().split(", "));
-		System.out.println(spamWords);
 		
 		final String[] taskWords = text.toLowerCase().split(" ");
 		
@@ -116,14 +115,12 @@ public class ManagerTaskUpdateService implements AbstractUpdateService<Manager, 
 		
 		for(final String word:taskWords) {
 			final String cleanWord = word.replaceAll("(?![À-ÿ\\u00f1\\u00d1a-zA-Z0-9]).", "");
-			System.out.println(cleanWord);
 			if(spamWords.contains(cleanWord)) {
 				numberSpamWords++;
 			}
 		}
 		
 		spamPercentaje = ((numberSpamWords/length)*100);
-		System.out.println(spamPercentaje);
 		if(spamPercentaje>spamObject.getThreshold()) {
 			return true;
 		}else {


### PR DESCRIPTION
Se han eliminado todos los System.out.println de los métodos de validación de palabras de spam y se ha añadido dicha validación para los campos "info" y "author" de la entidad shout.