### PR TITLE
Solucionados errores en los tests de las tareas para usuarios anónimos

### DIFF
--- a/src/test/java/acme/testing/anonymous/task/AnonymousTaskListByExPeriodTest.java
+++ b/src/test/java/acme/testing/anonymous/task/AnonymousTaskListByExPeriodTest.java
@@ -25,8 +25,8 @@ public class AnonymousTaskListByExPeriodTest extends AcmePlannerTest {
 		super.fillInputBoxIn("endExecution", endExecution);
 		super.fillInputBoxIn("info", info);
 		super.fillInputBoxIn("workload", workload);
-		super.fillInputBoxIn("newFinished", "False");
-		super.fillInputBoxIn("newStatus", "False");
+		super.fillInputBoxIn("newFinished", "false");
+		super.fillInputBoxIn("newStatus", "false");
 		super.clickOnSubmitButton("Submit");
 		super.clickOnMenu("Tasks", "My tasks");
 		

--- a/src/test/java/acme/testing/anonymous/task/AnonymousTaskListTest.java
+++ b/src/test/java/acme/testing/anonymous/task/AnonymousTaskListTest.java
@@ -25,8 +25,8 @@ public class AnonymousTaskListTest extends AcmePlannerTest {
 		super.fillInputBoxIn("endExecution", endExecution);
 		super.fillInputBoxIn("info", info);
 		super.fillInputBoxIn("workload", workload);
-		super.fillInputBoxIn("newFinished", "False");
-		super.fillInputBoxIn("newStatus", "False");
+		super.fillInputBoxIn("newFinished", "false");
+		super.fillInputBoxIn("newStatus", "false");
 		super.clickOnSubmitButton("Submit");
 		super.clickOnMenu("Tasks", "My tasks");
 		

--- a/src/test/java/acme/testing/anonymous/task/AnonymousTaskShowTest.java
+++ b/src/test/java/acme/testing/anonymous/task/AnonymousTaskShowTest.java
@@ -25,8 +25,8 @@ public class AnonymousTaskShowTest  extends AcmePlannerTest {
 		super.fillInputBoxIn("endExecution", endExecution);
 		super.fillInputBoxIn("info", info);
 		super.fillInputBoxIn("workload", workload);
-		super.fillInputBoxIn("newFinished", "False");
-		super.fillInputBoxIn("newStatus", "False");
+		super.fillInputBoxIn("newFinished", "false");
+		super.fillInputBoxIn("newStatus", "false");
 		super.clickOnSubmitButton("Submit");
 		super.clickOnMenu("Tasks", "My tasks");
 		


### PR DESCRIPTION
Se han corregido los errores dados en las clases AnonymousTaskListTests, AnonymousTaskListByExPeriodTests y AnonymousTaskShowTests debido a un cambio en los formularios correspondientes.